### PR TITLE
Make full style for noscript unsafe HTML

### DIFF
--- a/src/setup/headerBoilerplate.js
+++ b/src/setup/headerBoilerplate.js
@@ -25,15 +25,12 @@ export default href => [
     />
   ),
   (
-    <noscript key={key('noscript')}>
-      <style
-        amp-boilerplate=""
-        dangerouslySetInnerHTML={{
-          __html: `
-            body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}
-          `,
-        }}
-      />
-    </noscript>
+    <noscript key={key('noscript')}
+      dangerouslySetInnerHTML={{
+        __html: `
+          <style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style>
+        `,
+      }}
+    />
   ),
 ];


### PR DESCRIPTION
I am trying to use https://github.com/nfl/react-helmet to render AMP pages via SSR. Unfortunately Helmet doesn't support React components inside of `<nosccript>` tags. Doesn't seem like there's much harm in just rendering the full contents as unsafeInnerHTML rather than just the content of the style tag.