### PR TITLE
[amp-state] fix ts-ignore in rendered output

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4358,8 +4358,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4380,14 +4379,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4402,20 +4399,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4532,8 +4526,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4545,7 +4538,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4560,7 +4552,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4568,14 +4559,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4594,7 +4583,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4675,8 +4663,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4688,7 +4675,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4774,8 +4760,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4811,7 +4796,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4831,7 +4815,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4875,14 +4858,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/src/__tests__/react-amphtml.spec.tsx
+++ b/src/__tests__/react-amphtml.spec.tsx
@@ -131,11 +131,12 @@ describe('react-amphtml', (): void => {
 
   it('renders amp-state & amp-bind properly, and only appends the amp-bind script', (): void => {
     const ampScripts = new AmpScripts();
+    const initialState = { text: 'Hello, World!' };
     const wrapper = mount(
       <AmpScriptsManager ampScripts={ampScripts}>
         <div>
           <Amp.AmpState specName="amp-state" id="myState">
-            {{ text: 'Hello, World!' }}
+            {initialState}
           </Amp.AmpState>
           <AmpHelpers.Bind text="myState.text">
             {(props): ReactElement => <div {...props} />}
@@ -149,6 +150,7 @@ describe('react-amphtml', (): void => {
     expect(ampScriptElements.length).toBe(2);
     expect(wrapper.find('[data-amp-bind-text="myState.text"]').length).toBe(1);
     expect(wrapper.find('amp-state').length).toBe(1);
+    expect(wrapper.find('amp-state').text()).toBe(JSON.stringify(initialState));
   });
 
   it('renders amphtml action `on` attribute properly', (): void => {

--- a/src/amphtml/components/AmpState.tsx
+++ b/src/amphtml/components/AmpState.tsx
@@ -16,12 +16,10 @@ const AmpState: React.FunctionComponent<AmpStateProps> = (
   contextHelper({ context, extension: 'amp-bind' });
 
   if (src) {
-    // @ts-ignore
     return <amp-state id={id} src={src} />;
   }
 
   return (
-    // @ts-ignore
     <amp-state id={id}>
       <script
         type="application/json"
@@ -30,7 +28,6 @@ const AmpState: React.FunctionComponent<AmpStateProps> = (
           __html: JSON.stringify(children),
         }}
       />
-      // @ts-ignore
     </amp-state>
   );
 };

--- a/src/amphtml/components/jsx.d.ts
+++ b/src/amphtml/components/jsx.d.ts
@@ -1,0 +1,5 @@
+declare namespace JSX {
+  interface IntrinsicElements {
+    'amp-state': any;
+  }
+}


### PR DESCRIPTION
I noticed when I used this project for a nextjs amp project, that the html output for amp-state had a
"//@ts-ignore" annotation in it.

It turns out that the final //@ts-ignore in the AmpState.tsx component (before the closing tag), was 
getting passed through as element text.

There are some really odd solutions to ts-ignore in jsx (https://github.com/Microsoft/TypeScript/issues/27552). But because this is a closing tag, the best 
option was just to extend the JSX.IntrinsicAttributes to include amp-state.

I verified the tests (added a new test that fails with the current master branch):
```
  ● react-amphtml › renders amp-state & amp-bind properly, and only appends the amp-bind script

    expect(received).toBe(expected) // Object.is equality

    Expected: "{\"text\":\"Hello, World!\"}"
    Received: "{\"text\":\"Hello, World!\"}//@ts-ignore"
```

And also linked it to my local project to ensure that the correct output is there (and it looks good).
Hopefully this can be merged, I'm loving this project.