### PR TITLE
feat: add layout proptypes from validator rules

### DIFF
--- a/codegen/componentCode/index.ts
+++ b/codegen/componentCode/index.ts
@@ -8,6 +8,7 @@ import {
 } from '../constants';
 import tagNameToComponentName from '../tagNameToComponentName';
 import propsCodeReducer from './lib/propsCodeReducer';
+import withLayout from './lib/withLayoutAttributes';
 import mandatoryComponentOverrideTemplate from './templates/mandatoryComponentOverrideTemplate';
 import componentOverrideTemplate from './templates/componentOverrideTemplate';
 import componentTemplate from './templates/componentTemplate';
@@ -22,6 +23,7 @@ export default newRules.tags.reduce(
       dupeName,
       attrs,
       attrLists,
+      ampLayout,
       requiresExtension,
       extensionSpec,
       mandatoryAncestorSuggestedAlternative,
@@ -40,7 +42,8 @@ export default newRules.tags.reduce(
       });
     }
 
-    const propsCode = propsCodeReducer({ tagName, attrs, attrLists });
+    const reducedAttributes = propsCodeReducer({ tagName, attrs, attrLists });
+    const propsCode = withLayout(reducedAttributes, ampLayout);
 
     const requiresExtensionContext = (Array.isArray(requiresExtension)
       ? requiresExtension

--- a/codegen/componentCode/lib/kababCase.ts
+++ b/codegen/componentCode/lib/kababCase.ts
@@ -1,0 +1,2 @@
+export default (attr: string): string =>
+  attr.toLowerCase().replace('_', '-');

--- a/codegen/componentCode/lib/kababCase.ts
+++ b/codegen/componentCode/lib/kababCase.ts
@@ -1,2 +1,1 @@
-export default (attr: string): string =>
-  attr.toLowerCase().replace('_', '-');
+export default (attr: string): string => attr.toLowerCase().replace('_', '-');

--- a/codegen/componentCode/lib/withLayoutAttributes.ts
+++ b/codegen/componentCode/lib/withLayoutAttributes.ts
@@ -1,0 +1,31 @@
+import kababCase from './kababCase';
+import { AmpLayout } from 'amphtml-validator-rules';
+import { PropsCode } from './propsCodeReducer';
+
+export default (propsCode: PropsCode, layout?: AmpLayout) => {
+  if (!layout) {
+    return propsCode;
+  }
+
+  const { supportedLayouts } = layout;
+  const layoutProps = supportedLayouts.map(kababCase).map(layout => `"${layout}"`);
+  const layoutInterface = layoutProps.join(' | ');
+
+  const { propTypesCode, defaultPropsCode, propsInterfaceCode } = propsCode;
+  const layoutPropTypesCode = {
+    layout: `PropTypes.oneOf<${layoutInterface}>([${layoutProps}])`,
+    width: 'PropTypes.string',
+    height: 'PropTypes.string',
+  };
+  const layoutInterfaceCode = {
+    layout: `${layoutInterface} | undefined`,
+    width: 'string | undefined',
+    height: 'string | undefined',
+  };
+
+  return {
+    propTypesCode: { ...propTypesCode, ...layoutPropTypesCode },
+    defaultPropsCode,
+    propsInterfaceCode: { ...propsInterfaceCode, ...layoutInterfaceCode },
+  };
+};

--- a/codegen/componentCode/lib/withLayoutAttributes.ts
+++ b/codegen/componentCode/lib/withLayoutAttributes.ts
@@ -1,14 +1,18 @@
-import kababCase from './kababCase';
 import { AmpLayout } from 'amphtml-validator-rules';
+import kababCase from './kababCase';
 import { PropsCode } from './propsCodeReducer';
 
-export default (propsCode: PropsCode, layout?: AmpLayout) => {
+export default (propsCode: PropsCode, layout?: AmpLayout): PropsCode => {
   if (!layout) {
     return propsCode;
   }
 
   const { supportedLayouts } = layout;
-  const layoutProps = supportedLayouts.map(kababCase).map(layout => `"${layout}"`);
+  const layoutProps = supportedLayouts.map(kababCase).map(
+    (layoutValue: string): string => {
+      return `"${layoutValue}"`;
+    },
+  );
   const layoutInterface = layoutProps.join(' | ');
 
   const { propTypesCode, defaultPropsCode, propsInterfaceCode } = propsCode;


### PR DESCRIPTION
- adds the following PropTypes to tags with `supportedLayouts` 
```
  layout: PropTypes.oneOf<
    "fill" | "fixed" | "fixed-height" | "flex-item" | "nodisplay" | "responsive"
  >(["fill", "fixed", "fixed-height", "flex-item", "nodisplay", "responsive"]),

  width: PropTypes.string,

  height: PropTypes.string,
```

- add typescript interface for the corresponding PropTypes 
```
  layout?:
    | "fill"
    | "fixed"
    | "fixed-height"
    | "flex-item"
    | "nodisplay"
    | "responsive"
    | undefined;

  width?: string | undefined;

  height?: string | undefined;
```